### PR TITLE
fix: no-op update_title when not inside tmux or screen

### DIFF
--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -14,6 +14,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
 @test "update_title: output contains the title text" {
   run zsh -c '
+    export TMUX=test
     source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
     update_title "vim"
   '
@@ -23,6 +24,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
 @test "update_title: long title output contains ellipsis" {
   run zsh -c '
+    export TMUX=test
     source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
     update_title "this-is-a-very-long-command-name"
   '
@@ -32,6 +34,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
 @test "update_title: percent signs in title are escaped" {
   run zsh -c '
+    export TMUX=test
     source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
     update_title "100%done"
   '
@@ -41,12 +44,46 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
 @test "update_title: wraps title in tmux escape sequence" {
   run zsh -c '
+    export TMUX=test
     source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
     update_title "zsh"
   '
   [[ "$status" -eq 0 ]]
   # ESC k ... ESC backslash
   [[ "$output" == $'\033k'*$'\033\\'* ]]
+}
+
+@test "update_title: emits nothing when not in tmux or screen" {
+  run zsh -c '
+    unset TMUX
+    export TERM=xterm-256color
+    source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
+    update_title "hermes"
+  '
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "update_title: emits title when TERM is screen*" {
+  run zsh -c '
+    unset TMUX
+    export TERM=screen-256color
+    source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
+    update_title "hermes"
+  '
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"hermes"* ]]
+}
+
+@test "update_title: emits title when TERM is tmux*" {
+  run zsh -c '
+    unset TMUX
+    export TERM=tmux-256color
+    source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
+    update_title "hermes"
+  '
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"hermes"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/zsh-tmux.plugin.zsh
+++ b/zsh-tmux.plugin.zsh
@@ -1,8 +1,27 @@
 #!/usr/bin/env zsh
 #
+
+# Return 0 when the current terminal understands the DCS title sequence
+# (`\ek<title>\e\\`), which is specific to tmux / GNU screen. Everywhere
+# else the sequence is not recognised and terminals such as Ghostty, Kitty
+# or Apple Terminal render the payload as literal text on the next line,
+# making it look like every command is being echoed back to the user.
+function _zsh_title__in_tmux_or_screen() {
+  [[ -n "$TMUX" ]] && return 0
+  case "$TERM" in
+    tmux*|screen*) return 0 ;;
+  esac
+  return 1
+}
+
 function update_title() {
   emulate -L zsh -o extendedglob
   setopt localoptions no_shwordsplit
+
+  # Only emit the DCS title sequence when it will actually be consumed.
+  # Outside tmux/screen this escape is invalid and leaks the title text
+  # onto the terminal (see issue: commands echoed after Enter).
+  _zsh_title__in_tmux_or_screen || return 0
 
   # parameters
   local title


### PR DESCRIPTION
## Problem

`update_title` always emits the tmux/screen DCS title sequence `\ek<title>\e\\`, even when the shell is running outside tmux/screen. That escape is only consumed by tmux and GNU screen — other terminals (Ghostty, Kitty, Apple Terminal, Alacritty, iTerm2 in some configurations, …) do not recognise `ESC k` as a valid escape introducer, so the payload leaks onto the screen as literal text.

### Reproduction

1. Plain Ghostty (or any non-tmux xterm-compatible terminal), no tmux session running.
2. `plugins=(zsh-tmux)` in `~/.zshrc`.
3. Open a new shell. Press Enter on an empty prompt, then type a command like `hermes` and press Enter.

### Observed

```
~ ❯
sh                       # <— leaked 'zsh' title payload (tail after terminal ate ESC k z)
~ ❯ hermes
hermes                   # <— leaked 'hermes' title payload from preexec
command output…
~ ❯
```

Every command appears to be "echoed back". Empty-Enter shows `sh` because the terminal consumes a couple of bytes of the `\ekzsh\e\\` sequence and renders the rest.

### Bisection

I bisected this through ~26 Oh-My-Zsh plugins in a user's setup and it reproduced with **only** `plugins=(zsh-tmux)` enabled — no other plugin required.

## Root cause

`printf '\033k%s\033\\' ...` in `update_title` is a DCS (Device Control String) sequence specific to tmux / GNU screen. The README already documents tmux as a hard requirement and recommends loading the plugin conditionally inside `$TMUX`, so there's no supported use case for emitting this sequence outside those environments.

## Fix

Guard the escape emission with a helper that returns true only when we're actually inside tmux or screen (`$TMUX` set, or `$TERM` matches `tmux*` / `screen*`). Outside those environments `update_title` becomes a silent no-op. Behaviour inside tmux/screen is unchanged (verified with an `xxd` byte-for-byte check).

```zsh
function _zsh_title__in_tmux_or_screen() {
  [[ -n "$TMUX" ]] && return 0
  case "$TERM" in
    tmux*|screen*) return 0 ;;
  esac
  return 1
}

function update_title() {
  emulate -L zsh -o extendedglob
  setopt localoptions no_shwordsplit

  _zsh_title__in_tmux_or_screen || return 0
  # … existing body unchanged …
}
```

The `$TERM` check covers the common "I'm inside tmux but `$TMUX` got filtered by sudo/ssh" case; `$TMUX` covers the straight tmux parent case.

## Tests

- Existing `update_title` tests are updated to `export TMUX=test` inside the subshell — they implicitly depended on the escape being emitted unconditionally.
- Three new tests cover the guard:
  - silent when `$TMUX` unset and `$TERM=xterm-256color`
  - emits under `$TERM=screen-256color`
  - emits under `$TERM=tmux-256color`

```
$ bats tests/plugin.bats
1..13
ok 1 update_title: output contains the title text
ok 2 update_title: long title output contains ellipsis
ok 3 update_title: percent signs in title are escaped
ok 4 update_title: wraps title in tmux escape sequence
ok 5 update_title: emits nothing when not in tmux or screen
ok 6 update_title: emits title when TERM is screen*
ok 7 update_title: emits title when TERM is tmux*
ok 8 _zsh_title__precmd: calls update_title with 'zsh'
ok 9 _zsh_title__preexec: uses first word of command as title
ok 10 _zsh_title__preexec: uses first word from multi-word pipeline
ok 11 _zsh_title__preexec: single-word command is used as-is
ok 12 _zsh_title__preexec: fg with no active jobs uses fg as title
ok 13 _zsh_title__preexec: %+ with no active jobs uses %+ as title
```

## Manual verification

```zsh
# Outside tmux — silent (previously would have leaked 'hermes')
% TMUX= TERM=xterm-ghostty update_title "hermes"
% (no output)

# Inside tmux — unchanged
% TMUX=x update_title "hermes" | xxd
00000000: 1b6b 6865 726d 6573 1b5c                 .khermes.\
```

## Alternatives considered

Emit OSC 0 (`\e]0;<title>\a`) as a fallback outside tmux so non-tmux terminals get a proper window title. That's strictly more features, but it expands the plugin's stated scope (the README positions this as a *tmux* title manager) and introduces behaviour change for existing users on terminals that do something opinionated with OSC 0. A defensive no-op seemed safer and closer to the README's intent — happy to add the OSC 0 path in a follow-up if you'd prefer.
