### PR TITLE
feat: OSC 0 title fallback for non-tmux terminals (stacks on #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ source ~/.zsh/plugins/zsh-tmux/zsh-tmux.plugin.zsh
 
 Titles are capped at 20 characters and have newlines stripped and percent signs escaped.
 
+**Outside tmux:** the plugin falls back to OSC 0 (`ESC ] 0 ; <title> BEL`), the xterm-standard window-title sequence supported by Ghostty, Kitty, iTerm2, Apple Terminal, Alacritty, WezTerm, etc. — so non-tmux users get live window titles too.
+
+**On `TERM=dumb` / pipes / non-interactive shells:** no escape is emitted.
+
 ## Configuration
 
 ### Conditional Loading
@@ -65,6 +69,14 @@ Only load when inside tmux:
 if [[ -n "$TMUX" ]]; then
   zinit load zsh-contrib/zsh-tmux
 fi
+```
+
+### Disabling titles entirely
+
+Set `ZSH_TMUX_DISABLE_TITLE=1` before the plugin is sourced (or any time before `update_title` runs) to suppress all title updates — useful when another plugin or your prompt is already managing the window title.
+
+```zsh
+export ZSH_TMUX_DISABLE_TITLE=1
 ```
 
 ### Tmux Configuration

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -53,10 +53,51 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   [[ "$output" == $'\033k'*$'\033\\'* ]]
 }
 
-@test "update_title: emits nothing when not in tmux or screen" {
+@test "update_title: emits DCS sequence inside tmux/screen (TMUX set)" {
+  run zsh -c '
+    export TMUX=test
+    unset TERM
+    source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
+    update_title "hermes"
+  '
+  [[ "$status" -eq 0 ]]
+  # ESC k hermes ESC backslash
+  [[ "$output" == $'\033k'*"hermes"*$'\033\\'* ]]
+}
+
+@test "update_title: emits OSC 0 sequence outside tmux/screen" {
   run zsh -c '
     unset TMUX
     export TERM=xterm-256color
+    source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
+    # Force the OSC path: under bats, stdout is not a tty, so stub the
+    # capability check so we can observe what update_title emits.
+    _zsh_title__supports_osc_title() { return 0; }
+    update_title "hermes"
+  '
+  [[ "$status" -eq 0 ]]
+  # ESC ] 0 ; hermes BEL
+  [[ "$output" == $'\033]0;'*"hermes"*$'\a'* ]]
+  # And must NOT contain the DCS sequence
+  [[ "$output" != *$'\033k'* ]]
+}
+
+@test "update_title: emits nothing on dumb terminal outside tmux/screen" {
+  run zsh -c '
+    unset TMUX
+    export TERM=dumb
+    source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
+    _zsh_title__supports_osc_title() { return 1; }
+    update_title "hermes"
+  '
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "update_title: ZSH_TMUX_DISABLE_TITLE=1 silences everything" {
+  run zsh -c '
+    export TMUX=test
+    export ZSH_TMUX_DISABLE_TITLE=1
     source "$PLUGIN_DIR/zsh-tmux.plugin.zsh"
     update_title "hermes"
   '
@@ -64,7 +105,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   [[ -z "$output" ]]
 }
 
-@test "update_title: emits title when TERM is screen*" {
+@test "update_title: emits DCS when TERM is screen*" {
   run zsh -c '
     unset TMUX
     export TERM=screen-256color
@@ -72,10 +113,10 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     update_title "hermes"
   '
   [[ "$status" -eq 0 ]]
-  [[ "$output" == *"hermes"* ]]
+  [[ "$output" == $'\033k'*"hermes"*$'\033\\'* ]]
 }
 
-@test "update_title: emits title when TERM is tmux*" {
+@test "update_title: emits DCS when TERM is tmux*" {
   run zsh -c '
     unset TMUX
     export TERM=tmux-256color
@@ -83,7 +124,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     update_title "hermes"
   '
   [[ "$status" -eq 0 ]]
-  [[ "$output" == *"hermes"* ]]
+  [[ "$output" == $'\033k'*"hermes"*$'\033\\'* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/zsh-tmux.plugin.zsh
+++ b/zsh-tmux.plugin.zsh
@@ -14,14 +14,26 @@ function _zsh_title__in_tmux_or_screen() {
   return 1
 }
 
+# Return 0 when the current terminal is expected to understand the OSC 0
+# window-title sequence (`\e]0;<title>\a`). OSC 0 is the de-facto xterm
+# standard and is honoured by essentially every modern terminal; this
+# check is mostly a safety rail for explicitly dumb terminals (pipes,
+# `TERM=dumb`, plain `linux` console, etc.) where emitting OSC would be
+# at best wasted bytes and at worst leak text into a pager.
+function _zsh_title__supports_osc_title() {
+  [[ -t 1 ]] || return 1
+  case "$TERM" in
+    ''|dumb|linux|cons25|unknown) return 1 ;;
+  esac
+  return 0
+}
+
 function update_title() {
   emulate -L zsh -o extendedglob
   setopt localoptions no_shwordsplit
 
-  # Only emit the DCS title sequence when it will actually be consumed.
-  # Outside tmux/screen this escape is invalid and leaks the title text
-  # onto the terminal (see issue: commands echoed after Enter).
-  _zsh_title__in_tmux_or_screen || return 0
+  # Opt-out: users who set ZSH_TMUX_DISABLE_TITLE=1 get a complete no-op.
+  [[ "${ZSH_TMUX_DISABLE_TITLE:-0}" == 1 ]] && return 0
 
   # parameters
   local title
@@ -31,7 +43,20 @@ function update_title() {
   title=$(print -n -- "%20>...>$title")
   title=${title//$'\n'/}
 
-  printf '\033k%s\033\\' "${(%)title}"
+  # Expand prompt escapes once so both branches see the same text.
+  local expanded=${(%)title}
+
+  if _zsh_title__in_tmux_or_screen; then
+    # Inside tmux/screen: set the tmux window name via DCS. This is the
+    # plugin's original, canonical behaviour and the reason it exists.
+    printf '\033k%s\033\\' "$expanded"
+  elif _zsh_title__supports_osc_title; then
+    # Outside tmux/screen: set the terminal window title via OSC 0, so
+    # users on Ghostty, Kitty, iTerm2, Apple Terminal, Alacritty, etc.
+    # still get live "what is this pane doing" titles without leaking
+    # the DCS escape payload into the buffer.
+    printf '\033]0;%s\a' "$expanded"
+  fi
 }
 
 # called just before the prompt is printed


### PR DESCRIPTION
## Summary

Follow-up to #6. That PR guards the DCS title escape so non-tmux terminals stop seeing command text leak into the buffer. This PR takes the next step: when we're outside tmux/screen, actually **do** set the terminal window title, using the xterm-standard OSC 0 sequence (`\e]0;<title>\a`).

End result: non-tmux users finally get the same live "what is this pane running" titles that tmux users have always gotten from this plugin — on Ghostty, Kitty, iTerm2, Apple Terminal, Alacritty, WezTerm, and essentially every graphical terminal that implements the xterm title standard.

> ⚠️ **Stacked on #6.** This branch is cut from `fix/guard-dcs-outside-tmux` and includes its commit. The two commits are logically independent — #6 is a safety fix, this one is a feature — and are split for reviewability. If #6 merges first this PR will rebase cleanly. If you'd rather squash the two together into #6 directly, happy to do that.

## What this changes

```zsh
function update_title() {
  # ... prepare $title ...

  local expanded=${(%)title}

  if _zsh_title__in_tmux_or_screen; then
    printf '\033k%s\033\\' "$expanded"        # unchanged: tmux DCS
  elif _zsh_title__supports_osc_title; then
    printf '\033]0;%s\a' "$expanded"           # NEW: xterm OSC 0 fallback
  fi
}
```

And a small capability helper:

```zsh
function _zsh_title__supports_osc_title() {
  [[ -t 1 ]] || return 1
  case "$TERM" in
    ''|dumb|linux|cons25|unknown) return 1 ;;
  esac
  return 0
}
```

## Safety rails

- **Pipe-safe.** `[[ -t 1 ]]` — nothing is emitted when stdout is not a tty, so the escape can never leak into a pager, `tee`, or command substitution.
- **Dumb-terminal-safe.** `TERM` in `{'', dumb, linux, cons25, unknown}` short-circuits to silent, because OSC 0 on a Linux console prints the payload literally just like the original DCS bug.
- **Opt-out.** New `ZSH_TMUX_DISABLE_TITLE=1` env var disables the plugin entirely — for users whose prompt theme or another plugin is already managing the window title and doesn't want this one fighting for it.
- **tmux path unchanged.** Verified byte-for-byte with `xxd`:

    ```
    % TMUX=x update_title "hermes" | xxd
    00000000: 1b6b 6865 726d 6573 1b5c                 .khermes.\
    ```

## Why OSC 0 specifically

- OSC 0 = set icon name + window title. It's the canonical xterm title-setting escape and is supported by every graphical terminal that claims xterm compatibility.
- Alternatives considered:
  - **OSC 2** (window title only) — fine but OSC 0 also sets the icon name which is usually what users want in taskbars / dock tiles.
  - **OSC 1** (icon only) — not useful here.
  - **OSC 133** (prompt markers) — solves a different problem (prompt boundary tracking); orthogonal.

OSC 0 is the right default. Users who need finer control can layer their own escape on top; having a sensible default is the big win.

## Tests

Expanded from 13 → 16 (`bats tests/plugin.bats`):

```
1..16
ok 1 update_title: output contains the title text
ok 2 update_title: long title output contains ellipsis
ok 3 update_title: percent signs in title are escaped
ok 4 update_title: wraps title in tmux escape sequence
ok 5 update_title: emits DCS sequence inside tmux/screen (TMUX set)
ok 6 update_title: emits OSC 0 sequence outside tmux/screen
ok 7 update_title: emits nothing on dumb terminal outside tmux/screen
ok 8 update_title: ZSH_TMUX_DISABLE_TITLE=1 silences everything
ok 9 update_title: emits DCS when TERM is screen*
ok 10 update_title: emits DCS when TERM is tmux*
ok 11 _zsh_title__precmd: calls update_title with 'zsh'
ok 12 _zsh_title__preexec: uses first word of command as title
ok 13 _zsh_title__preexec: uses first word from multi-word pipeline
ok 14 _zsh_title__preexec: single-word command is used as-is
ok 15 _zsh_title__preexec: fg with no active jobs uses fg as title
ok 16 _zsh_title__preexec: %+ with no active jobs uses %+ as title
```

Test 6 stubs `_zsh_title__supports_osc_title` to force the OSC path, because `bats run` redirects stdout away from a tty so the `-t 1` check would otherwise short-circuit. The stub mirrors the real-world "interactive shell, real terminal" path and asserts the emitted bytes are exactly `\e]0;hermes\a` with **no** trailing DCS fragments.

## README

Added two short notes to the Behavior section documenting the OSC 0 fallback and the `ZSH_TMUX_DISABLE_TITLE` opt-out.

## Compatibility

Existing behaviour for tmux/screen users: **identical**. Users who opt in with the documented `if [[ -n "$TMUX" ]]` conditional load: still a no-op, because they never load the plugin outside tmux. Users who were loading the plugin unconditionally outside tmux: used to see broken text echoed; now see working window titles.

Closes #7.
