### PR TITLE
docs: clarify title-escape terminology; don't call ESC k ... ST a DCS

### DIFF
--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -53,7 +53,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   [[ "$output" == $'\033k'*$'\033\\'* ]]
 }
 
-@test "update_title: emits DCS sequence inside tmux/screen (TMUX set)" {
+@test "update_title: emits screen/tmux title escape inside tmux/screen (TMUX set)" {
   run zsh -c '
     export TMUX=test
     unset TERM
@@ -78,7 +78,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   [[ "$status" -eq 0 ]]
   # ESC ] 0 ; hermes BEL
   [[ "$output" == $'\033]0;'*"hermes"*$'\a'* ]]
-  # And must NOT contain the DCS sequence
+  # And must NOT contain the screen/tmux title escape introducer (ESC k)
   [[ "$output" != *$'\033k'* ]]
 }
 
@@ -105,7 +105,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   [[ -z "$output" ]]
 }
 
-@test "update_title: emits DCS when TERM is screen*" {
+@test "update_title: emits screen/tmux title escape when TERM is screen*" {
   run zsh -c '
     unset TMUX
     export TERM=screen-256color
@@ -116,7 +116,7 @@ PLUGIN_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   [[ "$output" == $'\033k'*"hermes"*$'\033\\'* ]]
 }
 
-@test "update_title: emits DCS when TERM is tmux*" {
+@test "update_title: emits screen/tmux title escape when TERM is tmux*" {
   run zsh -c '
     unset TMUX
     export TERM=tmux-256color

--- a/zsh-tmux.plugin.zsh
+++ b/zsh-tmux.plugin.zsh
@@ -14,10 +14,11 @@
 # shells via ssh, bare `screen`) are all covered.
 #
 # Why this matters: the `ESC k ... ST` sequence is a screen/tmux-private
-# control, not part of the ECMA-48 string-control family (DCS/OSC/APC/PM
-# /SOS all use distinct introducers). Terminals that aren't screen or
-# tmux don't recognise `ESC k` and render the payload as literal text,
-# making every command look like it's being echoed back to the user.
+# control, not part of the ECMA-48 string-control family
+# (DCS/OSC/APC/PM/SOS all use distinct introducers). Terminals that
+# aren't screen or tmux don't recognise `ESC k` and render the payload
+# as literal text, making every command look like it's being echoed back
+# to the user.
 function _zsh_title__in_tmux_or_screen() {
   [[ -n "$TMUX" ]] && return 0
   case "$TERM" in

--- a/zsh-tmux.plugin.zsh
+++ b/zsh-tmux.plugin.zsh
@@ -1,11 +1,23 @@
 #!/usr/bin/env zsh
 #
 
-# Return 0 when the current terminal understands the DCS title sequence
-# (`\ek<title>\e\\`), which is specific to tmux / GNU screen. Everywhere
-# else the sequence is not recognised and terminals such as Ghostty, Kitty
-# or Apple Terminal render the payload as literal text on the next line,
-# making it look like every command is being echoed back to the user.
+# Return 0 when the environment indicates the shell is running inside a
+# tmux or GNU screen session, i.e. when emitting the screen/tmux
+# title-setting escape (`ESC k <title> ESC \`, introduced by `ESC k` and
+# terminated by ST) is expected to be consumed by the multiplexer.
+#
+# This is an environment-based heuristic, not a terminal capability
+# probe: a user could in principle export TERM=tmux-256color or
+# TERM=screen-256color without actually being inside tmux/screen, in
+# which case the payload would still leak. Those configurations are
+# self-inflicted; the common cases (real tmux child processes, nested
+# shells via ssh, bare `screen`) are all covered.
+#
+# Why this matters: the `ESC k ... ST` sequence is a screen/tmux-private
+# control, not part of the ECMA-48 string-control family (DCS/OSC/APC/PM
+# /SOS all use distinct introducers). Terminals that aren't screen or
+# tmux don't recognise `ESC k` and render the payload as literal text,
+# making every command look like it's being echoed back to the user.
 function _zsh_title__in_tmux_or_screen() {
   [[ -n "$TMUX" ]] && return 0
   case "$TERM" in
@@ -47,14 +59,16 @@ function update_title() {
   local expanded=${(%)title}
 
   if _zsh_title__in_tmux_or_screen; then
-    # Inside tmux/screen: set the tmux window name via DCS. This is the
-    # plugin's original, canonical behaviour and the reason it exists.
+    # Inside tmux/screen: emit the screen/tmux title-setting escape
+    # (`ESC k <title> ESC \`). This is the plugin's original behaviour
+    # and the reason it exists; tmux/screen consume the sequence and
+    # update the window name.
     printf '\033k%s\033\\' "$expanded"
   elif _zsh_title__supports_osc_title; then
     # Outside tmux/screen: set the terminal window title via OSC 0, so
     # users on Ghostty, Kitty, iTerm2, Apple Terminal, Alacritty, etc.
     # still get live "what is this pane doing" titles without leaking
-    # the DCS escape payload into the buffer.
+    # the screen/tmux title escape into the buffer.
     printf '\033]0;%s\a' "$expanded"
   fi
 }


### PR DESCRIPTION
## Summary

Doc-only cleanup addressing Copilot's review feedback on #6 (tracked in #9). No behaviour changes, no new code paths, all 16 existing bats tests still pass.

Closes #9.

## Changes

### 1. Stop calling `ESC k … ST` a "DCS" sequence

**Copilot's comment (#6, review of `zsh-tmux.plugin.zsh` line 4):**
> In ECMA-48 terminology DCS sequences start with `ESC P`, so this wording is likely inaccurate/misleading. Consider rephrasing to something like "screen/tmux title escape sequence (`ESC k … ESC \`)" (or similar) to avoid claiming it is a DCS specifically.

Correct. ECMA-48 defines DCS as introduced by `ESC P` (0x1B 0x50) and terminated by ST. The `ESC k … ESC \` escape we use inside tmux/screen is a screen/tmux-private control — `k` (0x6B) is not one of the ECMA-48 string-control introducers (DCS/OSC/APC/PM/SOS all have distinct ones). It's commonly informally called a "DCS-like" sequence because it terminates with ST, but strictly speaking it is not DCS.

Replaced "DCS" with accurate phrasing ("screen/tmux title escape", "screen/tmux title-setting escape", or just the literal byte sequence) in:
- `zsh-tmux.plugin.zsh` — 2 inline comments inside `update_title`
- `tests/plugin.bats` — 3 test names + 1 inline comment

The **one** remaining `DCS` mention in the plugin is in a new explanatory block that says `ESC k … ST` is **not** part of the ECMA-48 family (DCS/OSC/APC/PM/SOS). That usage is intentional — it documents the distinction for anyone reading the source and wondering why terminals outside screen/tmux leak the payload.

### 2. Rewrite `_zsh_title__in_tmux_or_screen` docstring to match what it actually does

**Copilot's comment (#6, review of `zsh-tmux.plugin.zsh` line 24):**
> The helper name/comment says it detects when the "current terminal understands" the `ESC k … ESC \` sequence, but the implementation is really inferring whether output is expected to be consumed by tmux/screen based on `$TMUX`/`$TERM`. Since `$TERM` can be set to `screen*`/`tmux*` even when not actually under those multiplexers, consider adjusting the wording to match what the check actually guarantees (environment-based inference), so future readers don't treat this as a definitive terminal capability probe.

Also correct. The helper is an environment-based heuristic, not a capability probe. Anyone who manually exports `TERM=tmux-256color` on a plain xterm can still trip the leak, and the docstring shouldn't claim otherwise.

New docstring (excerpt):

```
# Return 0 when the environment indicates the shell is running inside a
# tmux or GNU screen session, i.e. when emitting the screen/tmux
# title-setting escape (`ESC k <title> ESC \`, introduced by `ESC k` and
# terminated by ST) is expected to be consumed by the multiplexer.
#
# This is an environment-based heuristic, not a terminal capability
# probe: a user could in principle export TERM=tmux-256color or
# TERM=screen-256color without actually being inside tmux/screen, in
# which case the payload would still leak. Those configurations are
# self-inflicted; the common cases (real tmux child processes, nested
# shells via ssh, bare `screen`) are all covered.
#
# Why this matters: the `ESC k ... ST` sequence is a screen/tmux-private
# control, not part of the ECMA-48 string-control family (DCS/OSC/APC/PM
# /SOS all use distinct introducers). Terminals that aren't screen or
# tmux don't recognise `ESC k` and render the payload as literal text,
# making every command look like it's being echoed back to the user.
```

### 3. Copilot's third comment is already resolved by #8

**Copilot's comment (#6, review of `tests/plugin.bats` line 87):**
> The TERM-based tests only assert that the output contains "hermes". This would still pass if `update_title` accidentally started printing plain text without the required `ESC k … ESC \\` wrapper…

Valid against #6 in isolation, but #8 already tightened those two tests to assert the full `$'\033k'*"hermes"*$'\033\\\\'*` wrapper. No further action needed. Noted in #9 for completeness.

## Tests

```
$ bats tests/plugin.bats
1..16
ok 1 update_title: output contains the title text
ok 2 update_title: long title output contains ellipsis
ok 3 update_title: percent signs in title are escaped
ok 4 update_title: wraps title in tmux escape sequence
ok 5 update_title: emits screen/tmux title escape inside tmux/screen (TMUX set)
ok 6 update_title: emits OSC 0 sequence outside tmux/screen
ok 7 update_title: emits nothing on dumb terminal outside tmux/screen
ok 8 update_title: ZSH_TMUX_DISABLE_TITLE=1 silences everything
ok 9 update_title: emits screen/tmux title escape when TERM is screen*
ok 10 update_title: emits screen/tmux title escape when TERM is tmux*
ok 11 _zsh_title__precmd: calls update_title with 'zsh'
ok 12 _zsh_title__preexec: uses first word of command as title
ok 13 _zsh_title__preexec: uses first word from multi-word pipeline
ok 14 _zsh_title__preexec: single-word command is used as-is
ok 15 _zsh_title__preexec: fg with no active jobs uses fg as title
ok 16 _zsh_title__preexec: %+ with no active jobs uses %+ as title
```

## Diff stat

```
tests/plugin.bats   |  8 ++++----
zsh-tmux.plugin.zsh | 30 ++++++++++++++++++++++--------
2 files changed, 26 insertions(+), 12 deletions(-)
```

## References

- Copilot review on #6 (comment IDs 3150733328, 3150733341, 3150733356)
- ECMA-48 §8.3.27 (DCS), §8.3.89 (OSC)
- `xterm(1)` "Controls beginning with ESC" table
- `tmux(1)` man page, `set-titles` section
